### PR TITLE
feat: replace Dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>serverless-ca/renovate-config",
+    "github>serverless-ca/renovate-config:github-actions",
+    "github>serverless-ca/renovate-config:python-packages",
+    "github>serverless-ca/renovate-config:internal-terraform-modules"
+  ]
+}


### PR DESCRIPTION
Switch to centralised Renovate configuration from
serverless-ca/renovate-config. Extends shared presets for GitHub Actions (SHA-pinned, automerge all), Python packages (automerge minor/patch, separate PRs for major), and internal Terraform modules (serverless-ca/ca/aws auto-update with no cooldown).

Removes Dependabot configuration as Renovate now handles all dependency updates.